### PR TITLE
chore(deps): upgrade Spring Boot, token-support, and PostgreSQL dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <springdoc.openapi.starter.version>3.0.1</springdoc.openapi.starter.version>
         <logstash.logback.encoder.version>8.1</logstash.logback.encoder.version>
         <eux.versions.maven.plugin.version>0.0.2</eux.versions.maven.plugin.version>
-        <eux.logging.version>1.0.4</eux.logging.version>
+        <eux.logging.version>1.0.5</eux.logging.version>
         <commons.text.version>1.14.0</commons.text.version>
         <graphql.java.extended.scalars.version>24.0</graphql.java.extended.scalars.version>
         <okhttp3.version>4.12.0</okhttp3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <kotlin.version>2.2.21</kotlin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>4.0.1</spring.boot.version>
-        <token.support.version>6.0.1</token.support.version>
+        <spring.boot.version>4.0.3</spring.boot.version>
+        <token.support.version>6.0.3</token.support.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
@@ -22,7 +22,7 @@
         <kotest.version>6.0.7</kotest.version>
         <junit.jupiter.engine.version>6.0.1</junit.jupiter.engine.version>
         <hikaricp.version>7.0.2</hikaricp.version>
-        <postgresql.version>42.7.8</postgresql.version>
+        <postgresql.version>42.7.10</postgresql.version>
         <springdoc.openapi.starter.version>3.0.1</springdoc.openapi.starter.version>
         <logstash.logback.encoder.version>8.1</logstash.logback.encoder.version>
         <eux.versions.maven.plugin.version>0.0.2</eux.versions.maven.plugin.version>


### PR DESCRIPTION
This PR upgrades the following dependencies to their latest patch versions:

- Spring Boot: 4.0.1 → 4.0.3
- NAV Token Support: 6.0.1 → 6.0.3
- PostgreSQL JDBC Driver: 42.7.8 → 42.7.10

These updates include bug fixes and security improvements.