### PR TITLE
chore(deps): bump spring boot to 4.0.4, token-support to 6.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <kotlin.version>2.2.21</kotlin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>4.0.3</spring.boot.version>
-        <token.support.version>6.0.3</token.support.version>
+        <spring.boot.version>4.0.4</spring.boot.version>
+        <token.support.version>6.0.4</token.support.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>


### PR DESCRIPTION
This PR updates the following dependencies:
- Spring Boot: 4.0.3 → 4.0.4
- Token Support: 6.0.3 → 6.0.4
These updates include bug fixes and improvements from the respective projects.