### PR TITLE
chore: upgrade Spring Boot to 4.0.5, jackson3 to 3.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
         <kotlin.version>2.2.21</kotlin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>4.0.4</spring.boot.version>
+        <spring.boot.version>4.0.5</spring.boot.version>
+        <jackson3.version>3.1.1</jackson3.version>
         <token.support.version>6.0.4</token.support.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
@@ -64,6 +65,16 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson3.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <spring.boot.version>4.0.5</spring.boot.version>
         <jackson3.version>3.1.1</jackson3.version>
-        <token.support.version>6.0.4</token.support.version>
+        <token.support.version>6.0.5</token.support.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>


### PR DESCRIPTION
To address vulnerabilities in transitive dependencies, i.e., netty (GHSA-w9fj-cfpg-grvv) and some Jackson3 stuff