### PR TITLE
chore(deps): bump dependencies and add Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 6
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 4
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - "navikt/eessibasis"
+    labels:
+      - "dependencies"
+      - "automerge"

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,12 @@
     <packaging>pom</packaging>
 
     <properties>
-        <kotlin.version>2.2.21</kotlin.version>
+        <kotlin.version>2.4.0</kotlin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>4.0.6</spring.boot.version>
-        <token.support.version>6.0.8</token.support.version>
+        <kotlin-maven-plugin.version>2.4.0</kotlin-maven-plugin.version>
+        <spring.boot.version>4.0.7</spring.boot.version>
+        <token.support.version>6.0.10</token.support.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
@@ -25,15 +26,15 @@
         <logstash.logback.encoder.version>8.1</logstash.logback.encoder.version>
         <eux.versions.maven.plugin.version>0.0.2</eux.versions.maven.plugin.version>
         <eux.logging.version>1.0.5</eux.logging.version>
-        <commons.text.version>1.14.0</commons.text.version>
+        <commons.text.version>1.15.0</commons.text.version>
         <graphql.java.extended.scalars.version>24.0</graphql.java.extended.scalars.version>
         <okhttp3.version>4.12.0</okhttp3.version>
-        <maven-scm-plugin.version>2.0.1</maven-scm-plugin.version>
-        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
-        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
-        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+        <maven-scm-plugin.version>2.2.1</maven-scm-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
+        <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     </properties>
 
@@ -155,6 +156,27 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.6.3</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                            <requireMavenVersion>
+                                <version>3.9.0</version>
+                            </requireMavenVersion>
+                        </rules>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -203,7 +225,7 @@
                 <plugin>
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-maven-plugin</artifactId>
-                    <version>${kotlin.version}</version>
+                    <version>${kotlin-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
- Add .github/dependabot.yaml for automated Maven dependency updates
- Upgrade Kotlin 2.2.21 → 2.4.0
- Upgrade Spring Boot 4.0.6 → 4.0.7
- Upgrade token-support 6.0.8 → 6.0.10
- Upgrade commons-text 1.14.0 → 1.15.0
- Upgrade Maven plugins: surefire, failsafe, compiler, jar, resources, scm
- Add maven-enforcer-plugin requiring Maven 3.9.0 minimum
- Extract kotlin-maven-plugin version to property for consistency