### PR TITLE
chore(deps): bump jackson BOMs to 2.22.0 (jackson2) and 3.2.0 (jackson3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-bom.version>3.2.0</jackson-bom.version>
     </properties>
 
     <scm>
@@ -151,6 +153,20 @@
                 <artifactId>mockwebserver</artifactId>
                 <version>${okhttp3.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-2-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Endringer

Legger til BOM-imports i `dependencyManagement` for å styre alle Jackson-moduler konsistent i child-prosjekter.

### Properties

| Property | Versjon |
|---|---|
| `jackson-2-bom.version` | `2.22.0` |
| `jackson-bom.version` | `3.2.0` |

### Avhengigheter lagt til

- `com.fasterxml.jackson:jackson-bom:2.22.0` (Jackson 2 — `com.fasterxml.jackson` groupId)
- `tools.jackson:jackson-bom:3.2.0` (Jackson 3 — `tools.jackson` groupId)

### Hvorfor BOM fremfor individuelle pins?

BOM-import sørger for at alle Jackson-moduler (`jackson-databind`, `jackson-annotations`, `jackson-core`, `jackson-module-kotlin`, `jackson-datatype-jsr310` osv.) får konsistente versjoner — ikke bare databind alene.