### PR TITLE
chore(deps): pin jackson-annotations to 2.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
         <jackson-bom.version>3.2.0</jackson-bom.version>
+        <jackson2.annotations.version>2.22</jackson2.annotations.version>
     </properties>
 
     <scm>
@@ -167,6 +168,11 @@
                 <version>${jackson-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson2.annotations.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Endringer

Legger til eksplisitt pin for `jackson-annotations:2.22` i `dependencyManagement`.

### Bakgrunn

`jackson-annotations` følger egen release-kadence, uavhengig av `jackson-databind` og jackson-BOM-versjoneringen. En eksplisitt `<dependency>`-entry overstyrer hva Spring Boot BOM definerer, og sikrer at riktig versjon brukes i alle child-prosjekter.

| Property | Verdi |
|---|---|
| `jackson2.annotations.version` | `2.22` |