### PR TITLE
chore(deps): pin jackson2 and jackson3 core artifacts explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,36 @@
                 <artifactId>jackson-annotations</artifactId>
                 <version>${jackson2.annotations.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-2-bom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson-2-bom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>${jackson-2-bom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson-2-bom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-bom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson-bom.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Problem

Spring Boot 4.0.7/4.1.0 sitt BOM håndterer Jackson til:
- Jackson 2: `2.21.4`
- Jackson 3: `3.1.4`

BOM-imports i `dependencyManagement` taper mot Spring Boot BOM p.g.a. rekkefølge — første BOM vinner. Eksplisitte `<dependency>`-entries overstyrer alltid alle BOM-imports.

## Løsning

Eksplisitte pins i `dependencyManagement` for Jackson 2 (`2-bom.version` = 2.22.0):
- `com.fasterxml.jackson.core:jackson-databind`
- `com.fasterxml.jackson.core:jackson-core`
- `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml`
- `com.fasterxml.jackson.datatype:jackson-datatype-jsr310`

Eksplisitte pins for Jackson 3 (`bom.version` = 3.2.0):
- `tools.jackson.core:jackson-databind`
- `tools.jackson.core:jackson-core`