### PR TITLE
chore(deps): pin jackson-module-kotlin for jackson2 and jackson3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,16 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson-bom.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-kotlin</artifactId>
+                <version>${jackson-2-bom.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.module</groupId>
+                <artifactId>jackson-module-kotlin</artifactId>
+                <version>${jackson-bom.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Endringer

Eksplisitte pins for Kotlin-modulene til begge Jackson-generasjoner.

| Artefakt | Versjon |
|---|---|
| `com.fasterxml.jackson.module:jackson-module-kotlin` | `2.22.0` |
| `tools.jackson.module:jackson-module-kotlin` | `3.2.0` |

## Bakgrunn

`jackson-module-kotlin` bruker interne APIer i `jackson-databind` tett. En versjonsmismatch mellom modul og databind kan gi runtime-feil ved serialisering av Kotlin data classes. Spring Boot BOM låser begge til eldre versjoner (2.21.4 / 3.1.4) som ikke matcher pinsene vi allerede har satt for databind.