### PR TITLE
Bump dependencies (Kotest 6.2.1; aligned to token-support 6.0.11 / Spring Boot 4.1.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
         <kotlin.logging.version>7.0.13</kotlin.logging.version>
-        <kotest.version>6.0.7</kotest.version>
+        <kotest.version>6.2.1</kotest.version>
         <junit.jupiter.engine.version>6.0.3</junit.jupiter.engine.version>
         <springdoc.openapi.starter.version>3.0.3</springdoc.openapi.starter.version>
         <logstash.logback.encoder.version>8.1</logstash.logback.encoder.version>


### PR DESCRIPTION
## Dependency bump — aligned set

Anchored on the latest **token-support** release; everything else aligned to the Spring Boot version it pins. The set was already almost fully aligned — only Kotest was behind.

| Property | Old | New | Source of truth |
|---|---|---|---|
| token.support.version | 6.0.11 | 6.0.11 (unchanged) | latest GitHub Packages release |
| spring.boot.version | 4.1.0 | 4.1.0 (unchanged) | token-support 6.0.11 pom.xml |
| kotlin.version | 2.3.21 | 2.3.21 (unchanged) | spring-boot-dependencies 4.1.0 |
| maven-*-plugin.version | — | unchanged | already matched spring-boot-dependencies 4.1.0 |
| junit.jupiter.engine.version | 6.0.3 | 6.0.3 (unchanged) | spring-boot-dependencies 4.1.0 |
| **kotest.version** | **6.0.7** | **6.2.1** | latest stable; adds Kotlin 2.3 support |

### Verification
- `mvn clean install` on `eux-parent-pom` ✅
- `eux-nav-rinasak` `clean install` against the newly built parent — all modules & tests ✅

### Not bumped (and why)
- **token-support / Spring Boot / Kotlin / maven-\* plugins** — already at the aligned target for the current Spring Boot 4.1.0; no change needed.
- **maven-scm-plugin** — not managed by spring-boot-dependencies; left as-is.
- **EUX/NAV-internal libs** (eux-logging, springdoc, kotlin-logging, graphql-scalars, etc.) — out of scope for this alignment bump; left as-is.

_Note: Kotlin follows Spring Boot (2.3.21), not token-support (which pins 2.2.21)._